### PR TITLE
Make the objective dialog wider and allow line breaks

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -162,7 +162,7 @@ export const SharedConversation = ({
           }}
         >
           <DialogContent
-            className="sm:max-w-[425px]"
+            className="sm:max-w-[1024px]"
             // Prevent closing by clicking outside
             onPointerDownOutside={(e) => e.preventDefault()}
             // Prevent closing by pressing escape
@@ -170,7 +170,7 @@ export const SharedConversation = ({
           >
             <DialogHeader className="text-center">
               <DialogTitle>Game Objective</DialogTitle>
-              <DialogDescription>
+              <DialogDescription style={{ whiteSpace: "pre-line" }}>
                 <br className="mb-4" />
                 <span className=" font-bold text-white mt-3">
                   Objective


### PR DESCRIPTION
Suggestions:
1. Allow line breaks in objectives (to show, e.g., policy and scenario in NoRefund)
2. Make the dialog wider, if we need to show policy and scenario which are kind of long